### PR TITLE
[1.7.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [[1.7.1]](https://commercemarketplace.adobe.com/fortispay-magento-2-payment-gateway.html#product.info.details.release_notes)
+
+### Fixed
+
+- Truncated Fortis Level 3 line-item fields before API submission to meet gateway validation limits:
+    - `level3_data.line_items[*].description` is now capped at 26 characters.
+    - `level3_data.line_items[*].product_code` is now capped at 12 characters.
+
 ## [[1.7.0]](https://commercemarketplace.adobe.com/fortispay-magento-2-payment-gateway.html#product.info.details.release_notes)
 
 ### Added

--- a/Model/FortisApi.php
+++ b/Model/FortisApi.php
@@ -465,9 +465,9 @@ class FortisApi
             $product  = $item->getProduct();
             $unitCost = (int)bcmul((string)$product->getPrice(), '100', 0);
             $lineItem = [
-                'description'    => $item->getName(),
+                'description'    => mb_substr((string)$item->getName(), 0, 26),
                 'commodity_code' => $product->getCustomAttribute('commodity_code')?->getValue() ?: '0',
-                'product_code'   => $item->getSku(),
+                'product_code'   => mb_substr((string)$item->getSku(), 0, 12),
                 'unit_code'      => $product->getCustomAttribute('unit_code')?->getValue() ?: 'EA',
                 'unit_cost'      => $unitCost,
                 'quantity'       => (int)$item->getQtyOrdered(),
@@ -529,8 +529,8 @@ class FortisApi
             $product  = $item->getProduct();
             $unitCost = (int)bcmul((string)$product->getPrice(), '100', 0);
             $lineItem = [
-                'description'      => $item->getName(),
-                'product_code'     => $item->getSku(),
+                'description'      => mb_substr((string)$item->getName(), 0, 26),
+                'product_code'     => mb_substr((string)$item->getSku(), 0, 12),
                 'unit_code'        => $product->getCustomAttribute('unit_code')?->getValue() ?: 'EA',
                 'unit_cost'        => $unitCost,
                 'quantity'         => (int)$item->getQtyOrdered(),

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "fortispay/magento-2-payment-gateway",
   "description": "FortisPay Payment Gateway for Magento 2",
   "type": "magento2-module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "minimum-stability": "stable",
   "license": "GPL-3.0",
   "authors": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Fortispay_Fortis" setup_version="1.7.0">
+    <module name="Fortispay_Fortis" setup_version="1.7.1">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
### Fixed

- Truncated Fortis Level 3 line-item fields before API submission to meet gateway validation limits:
    - `level3_data.line_items[*].description` is now capped at 26 characters.
    - `level3_data.line_items[*].product_code` is now capped at 12 characters.